### PR TITLE
Email & encoding fixes

### DIFF
--- a/Bugzilla/Config/Auth.pm
+++ b/Bugzilla/Config/Auth.pm
@@ -99,7 +99,7 @@ sub get_param_list {
   {
    name => 'emailregexp',
    type => 't',
-   default => q:^[\\w\\.\\+\\-=]+@[\\w\\.\\-]+\\.[\\w\\-]+$:,
+   default => q:^"?[\\w\\.\\+\\-=%!]+"?@[\\w\\.\\-]+\\.[\\w\\-]+$:,
    checker => \&check_regexp
   },
 

--- a/Bugzilla/Migrate/Gnats.pm
+++ b/Bugzilla/Migrate/Gnats.pm
@@ -372,7 +372,7 @@ sub _parse_project {
 sub _parse_bug_file {
     my ($self, $file) = @_;
     $self->debug("Reading $file");
-    open(my $fh, "<", $file) || die "$file: $!";
+    open(my $fh, "< :encoding(Latin1)", $file) || die "$file: $!";
     my $email = Email::Simple::FromHandle->new($fh);
     my $fields = $self->_get_gnats_field_data($email);
     # We parse attachments here instead of during translate_bug,

--- a/Bugzilla/Migrate/GnatsAttachment.pm
+++ b/Bugzilla/Migrate/GnatsAttachment.pm
@@ -100,10 +100,10 @@ sub ParsePatches
 		}
 
 		$formatted .= "--$boundary\n";
-		$formatted .= "Content-Type: " . $pi->{ctype} . "; name=" . $pi->{name} . "\n";
+		$formatted .= "Content-Type: " . $pi->{ctype} . "; name=\"" . $pi->{name} . "\"\n";
 		$formatted .= "Content-Transfer-Encoding: " . $pi->{encoding} . "\n";
 		$formatted .= "Content-Disposition: attachment;";
-	        $formatted .= " filename=" .$pi->{name} . "\n\n"; # XXX - Generate random if undef.
+	        $formatted .= " filename=\"" .$pi->{name} . "\"\n\n"; # XXX - Generate random if undef.
 
 	        $formatted .= substr($$text,
 			       	0,
@@ -222,7 +222,7 @@ sub FindPatchEnd
 		$$text =~ /$/
 			and $pi->{size} = $+[0];
 	} elsif ($pi->{type} eq 'stdattach') {
-		$$text =~ /^---{1,8}\s?\Q$pi->{name}\E ends here\s?---+/mi
+		$$text =~ /^\s*---{1,8}\s?\Q$pi->{name}\E ends here\s?---+/mi
 			and $pi->{size} = $-[0]-1;
 		# Chop footer line
         # print "----> '$$text' <----, name = " . $pi->{name} . "\n";

--- a/Bugzilla/Util.pm
+++ b/Bugzilla/Util.pm
@@ -600,7 +600,7 @@ sub _do_srand {
 sub validate_email_syntax {
     my ($addr) = @_;
     my $match = Bugzilla->params->{'emailregexp'};
-    my $ret = ($addr =~ /$match/ && $addr !~ /[\\\(\)<>&,;:"\[\] \t\r\n\P{ASCII}]/);
+    my $ret = ($addr =~ /$match/ && $addr !~ /[\\\(\)<>&,;:\[\] \t\r\n\P{ASCII}]/);
     if ($ret) {
         # We assume these checks to suffice to consider the address untainted.
         trick_taint($_[0]);


### PR DESCRIPTION
- Make email parser more permissive. It might be not OK for live system, but for converter it's OK: we need to handle emails like "."@domain.com, firstname%lastname@domain.com

- Force latin1 encoding for PRs